### PR TITLE
Patch the instruction discriminant to be 4 bytes

### DIFF
--- a/clients/js/src/generated/instructions/deploy.ts
+++ b/clients/js/src/generated/instructions/deploy.ts
@@ -10,8 +10,8 @@ import {
   combineCodec,
   getStructDecoder,
   getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
+  getU32Decoder,
+  getU32Encoder,
   transformEncoder,
   type Address,
   type Codec,
@@ -32,7 +32,7 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const DEPLOY_DISCRIMINATOR = 2;
 
 export function getDeployDiscriminatorBytes() {
-  return getU8Encoder().encode(DEPLOY_DISCRIMINATOR);
+  return getU32Encoder().encode(DEPLOY_DISCRIMINATOR);
 }
 
 export type DeployInstruction<
@@ -65,13 +65,13 @@ export type DeployInstructionDataArgs = {};
 
 export function getDeployInstructionDataEncoder(): Encoder<DeployInstructionDataArgs> {
   return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
+    getStructEncoder([['discriminator', getU32Encoder()]]),
     (value) => ({ ...value, discriminator: DEPLOY_DISCRIMINATOR })
   );
 }
 
 export function getDeployInstructionDataDecoder(): Decoder<DeployInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+  return getStructDecoder([['discriminator', getU32Decoder()]]);
 }
 
 export function getDeployInstructionDataCodec(): Codec<

--- a/clients/js/src/generated/instructions/finalize.ts
+++ b/clients/js/src/generated/instructions/finalize.ts
@@ -10,8 +10,8 @@ import {
   combineCodec,
   getStructDecoder,
   getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
+  getU32Decoder,
+  getU32Encoder,
   transformEncoder,
   type Address,
   type Codec,
@@ -33,7 +33,7 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const FINALIZE_DISCRIMINATOR = 5;
 
 export function getFinalizeDiscriminatorBytes() {
-  return getU8Encoder().encode(FINALIZE_DISCRIMINATOR);
+  return getU32Encoder().encode(FINALIZE_DISCRIMINATOR);
 }
 
 export type FinalizeInstruction<
@@ -66,13 +66,13 @@ export type FinalizeInstructionDataArgs = {};
 
 export function getFinalizeInstructionDataEncoder(): Encoder<FinalizeInstructionDataArgs> {
   return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
+    getStructEncoder([['discriminator', getU32Encoder()]]),
     (value) => ({ ...value, discriminator: FINALIZE_DISCRIMINATOR })
   );
 }
 
 export function getFinalizeInstructionDataDecoder(): Decoder<FinalizeInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+  return getStructDecoder([['discriminator', getU32Decoder()]]);
 }
 
 export function getFinalizeInstructionDataCodec(): Codec<

--- a/clients/js/src/generated/instructions/retract.ts
+++ b/clients/js/src/generated/instructions/retract.ts
@@ -10,8 +10,8 @@ import {
   combineCodec,
   getStructDecoder,
   getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
+  getU32Decoder,
+  getU32Encoder,
   transformEncoder,
   type Address,
   type Codec,
@@ -32,7 +32,7 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const RETRACT_DISCRIMINATOR = 3;
 
 export function getRetractDiscriminatorBytes() {
-  return getU8Encoder().encode(RETRACT_DISCRIMINATOR);
+  return getU32Encoder().encode(RETRACT_DISCRIMINATOR);
 }
 
 export type RetractInstruction<
@@ -61,13 +61,13 @@ export type RetractInstructionDataArgs = {};
 
 export function getRetractInstructionDataEncoder(): Encoder<RetractInstructionDataArgs> {
   return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
+    getStructEncoder([['discriminator', getU32Encoder()]]),
     (value) => ({ ...value, discriminator: RETRACT_DISCRIMINATOR })
   );
 }
 
 export function getRetractInstructionDataDecoder(): Decoder<RetractInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+  return getStructDecoder([['discriminator', getU32Decoder()]]);
 }
 
 export function getRetractInstructionDataCodec(): Codec<

--- a/clients/js/src/generated/instructions/transferAuthority.ts
+++ b/clients/js/src/generated/instructions/transferAuthority.ts
@@ -10,8 +10,8 @@ import {
   combineCodec,
   getStructDecoder,
   getStructEncoder,
-  getU8Decoder,
-  getU8Encoder,
+  getU32Decoder,
+  getU32Encoder,
   transformEncoder,
   type Address,
   type Codec,
@@ -32,7 +32,7 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const TRANSFER_AUTHORITY_DISCRIMINATOR = 4;
 
 export function getTransferAuthorityDiscriminatorBytes() {
-  return getU8Encoder().encode(TRANSFER_AUTHORITY_DISCRIMINATOR);
+  return getU32Encoder().encode(TRANSFER_AUTHORITY_DISCRIMINATOR);
 }
 
 export type TransferAuthorityInstruction<
@@ -66,13 +66,13 @@ export type TransferAuthorityInstructionDataArgs = {};
 
 export function getTransferAuthorityInstructionDataEncoder(): Encoder<TransferAuthorityInstructionDataArgs> {
   return transformEncoder(
-    getStructEncoder([['discriminator', getU8Encoder()]]),
+    getStructEncoder([['discriminator', getU32Encoder()]]),
     (value) => ({ ...value, discriminator: TRANSFER_AUTHORITY_DISCRIMINATOR })
   );
 }
 
 export function getTransferAuthorityInstructionDataDecoder(): Decoder<TransferAuthorityInstructionData> {
-  return getStructDecoder([['discriminator', getU8Decoder()]]);
+  return getStructDecoder([['discriminator', getU32Decoder()]]);
 }
 
 export function getTransferAuthorityInstructionDataCodec(): Codec<

--- a/clients/js/src/generated/instructions/truncate.ts
+++ b/clients/js/src/generated/instructions/truncate.ts
@@ -12,8 +12,6 @@ import {
   getStructEncoder,
   getU32Decoder,
   getU32Encoder,
-  getU8Decoder,
-  getU8Encoder,
   transformEncoder,
   type Address,
   type Codec,
@@ -35,7 +33,7 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const TRUNCATE_DISCRIMINATOR = 1;
 
 export function getTruncateDiscriminatorBytes() {
-  return getU8Encoder().encode(TRUNCATE_DISCRIMINATOR);
+  return getU32Encoder().encode(TRUNCATE_DISCRIMINATOR);
 }
 
 export type TruncateInstruction<
@@ -73,7 +71,7 @@ export type TruncateInstructionDataArgs = { newSize: number };
 export function getTruncateInstructionDataEncoder(): Encoder<TruncateInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([
-      ['discriminator', getU8Encoder()],
+      ['discriminator', getU32Encoder()],
       ['newSize', getU32Encoder()],
     ]),
     (value) => ({ ...value, discriminator: TRUNCATE_DISCRIMINATOR })
@@ -82,7 +80,7 @@ export function getTruncateInstructionDataEncoder(): Encoder<TruncateInstruction
 
 export function getTruncateInstructionDataDecoder(): Decoder<TruncateInstructionData> {
   return getStructDecoder([
-    ['discriminator', getU8Decoder()],
+    ['discriminator', getU32Decoder()],
     ['newSize', getU32Decoder()],
   ]);
 }

--- a/clients/js/src/generated/instructions/write.ts
+++ b/clients/js/src/generated/instructions/write.ts
@@ -16,8 +16,6 @@ import {
   getStructEncoder,
   getU32Decoder,
   getU32Encoder,
-  getU8Decoder,
-  getU8Encoder,
   transformEncoder,
   type Address,
   type Codec,
@@ -39,7 +37,7 @@ import { getAccountMetaFactory, type ResolvedAccount } from '../shared';
 export const WRITE_DISCRIMINATOR = 0;
 
 export function getWriteDiscriminatorBytes() {
-  return getU8Encoder().encode(WRITE_DISCRIMINATOR);
+  return getU32Encoder().encode(WRITE_DISCRIMINATOR);
 }
 
 export type WriteInstruction<
@@ -76,7 +74,7 @@ export type WriteInstructionDataArgs = {
 export function getWriteInstructionDataEncoder(): Encoder<WriteInstructionDataArgs> {
   return transformEncoder(
     getStructEncoder([
-      ['discriminator', getU8Encoder()],
+      ['discriminator', getU32Encoder()],
       ['offset', getU32Encoder()],
       ['bytes', addEncoderSizePrefix(getBytesEncoder(), getU32Encoder())],
     ]),
@@ -86,7 +84,7 @@ export function getWriteInstructionDataEncoder(): Encoder<WriteInstructionDataAr
 
 export function getWriteInstructionDataDecoder(): Decoder<WriteInstructionData> {
   return getStructDecoder([
-    ['discriminator', getU8Decoder()],
+    ['discriminator', getU32Decoder()],
     ['offset', getU32Decoder()],
     ['bytes', addDecoderSizePrefix(getBytesDecoder(), getU32Decoder())],
   ]);

--- a/clients/js/src/generated/programs/loaderV4.ts
+++ b/clients/js/src/generated/programs/loaderV4.ts
@@ -8,7 +8,7 @@
 
 import {
   containsBytes,
-  getU8Encoder,
+  getU32Encoder,
   type Address,
   type ReadonlyUint8Array,
 } from '@solana/web3.js';
@@ -37,22 +37,22 @@ export function identifyLoaderV4Instruction(
   instruction: { data: ReadonlyUint8Array } | ReadonlyUint8Array
 ): LoaderV4Instruction {
   const data = 'data' in instruction ? instruction.data : instruction;
-  if (containsBytes(data, getU8Encoder().encode(0), 0)) {
+  if (containsBytes(data, getU32Encoder().encode(0), 0)) {
     return LoaderV4Instruction.Write;
   }
-  if (containsBytes(data, getU8Encoder().encode(1), 0)) {
+  if (containsBytes(data, getU32Encoder().encode(1), 0)) {
     return LoaderV4Instruction.Truncate;
   }
-  if (containsBytes(data, getU8Encoder().encode(2), 0)) {
+  if (containsBytes(data, getU32Encoder().encode(2), 0)) {
     return LoaderV4Instruction.Deploy;
   }
-  if (containsBytes(data, getU8Encoder().encode(3), 0)) {
+  if (containsBytes(data, getU32Encoder().encode(3), 0)) {
     return LoaderV4Instruction.Retract;
   }
-  if (containsBytes(data, getU8Encoder().encode(4), 0)) {
+  if (containsBytes(data, getU32Encoder().encode(4), 0)) {
     return LoaderV4Instruction.TransferAuthority;
   }
-  if (containsBytes(data, getU8Encoder().encode(5), 0)) {
+  if (containsBytes(data, getU32Encoder().encode(5), 0)) {
     return LoaderV4Instruction.Finalize;
   }
   throw new Error(

--- a/clients/rust/src/generated/instructions/deploy.rs
+++ b/clients/rust/src/generated/instructions/deploy.rs
@@ -56,7 +56,7 @@ impl Deploy {
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct DeployInstructionData {
-    discriminator: u8,
+    discriminator: u32,
 }
 
 impl DeployInstructionData {

--- a/clients/rust/src/generated/instructions/finalize.rs
+++ b/clients/rust/src/generated/instructions/finalize.rs
@@ -51,7 +51,7 @@ impl Finalize {
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct FinalizeInstructionData {
-    discriminator: u8,
+    discriminator: u32,
 }
 
 impl FinalizeInstructionData {

--- a/clients/rust/src/generated/instructions/retract.rs
+++ b/clients/rust/src/generated/instructions/retract.rs
@@ -45,7 +45,7 @@ impl Retract {
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct RetractInstructionData {
-    discriminator: u8,
+    discriminator: u32,
 }
 
 impl RetractInstructionData {

--- a/clients/rust/src/generated/instructions/transfer_authority.rs
+++ b/clients/rust/src/generated/instructions/transfer_authority.rs
@@ -53,7 +53,7 @@ impl TransferAuthority {
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct TransferAuthorityInstructionData {
-    discriminator: u8,
+    discriminator: u32,
 }
 
 impl TransferAuthorityInstructionData {

--- a/clients/rust/src/generated/instructions/truncate.rs
+++ b/clients/rust/src/generated/instructions/truncate.rs
@@ -64,7 +64,7 @@ impl Truncate {
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct TruncateInstructionData {
-    discriminator: u8,
+    discriminator: u32,
 }
 
 impl TruncateInstructionData {

--- a/clients/rust/src/generated/instructions/write.rs
+++ b/clients/rust/src/generated/instructions/write.rs
@@ -51,7 +51,7 @@ impl Write {
 
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct WriteInstructionData {
-    discriminator: u8,
+    discriminator: u32,
 }
 
 impl WriteInstructionData {

--- a/program/idl.json
+++ b/program/idl.json
@@ -33,7 +33,7 @@
         }
       ],
       "discriminant": {
-        "type": "u8",
+        "type": "u32",
         "value": 0
       }
     },
@@ -73,7 +73,7 @@
         }
       ],
       "discriminant": {
-        "type": "u8",
+        "type": "u32",
         "value": 1
       }
     },
@@ -108,7 +108,7 @@
       ],
       "args": [],
       "discriminant": {
-        "type": "u8",
+        "type": "u32",
         "value": 2
       }
     },
@@ -134,7 +134,7 @@
       ],
       "args": [],
       "discriminant": {
-        "type": "u8",
+        "type": "u32",
         "value": 3
       }
     },
@@ -168,7 +168,7 @@
       ],
       "args": [],
       "discriminant": {
-        "type": "u8",
+        "type": "u32",
         "value": 4
       }
     },
@@ -202,7 +202,7 @@
       ],
       "args": [],
       "discriminant": {
-        "type": "u8",
+        "type": "u32",
         "value": 5
       }
     }

--- a/scripts/generate-idls.mjs
+++ b/scripts/generate-idls.mjs
@@ -15,6 +15,16 @@ getProgramFolders().forEach((folder) => {
     programName: cargo.package.name.replace(/-/g, '_'),
     programId: cargo.package.metadata.solana['program-id'],
     idlDir: programDir,
+    idlHook: (idl) => ({
+      ...idl,
+      instructions: idl.instructions.map((instruction) => ({
+        ...instruction,
+        discriminant: {
+          ...instruction.discriminant,
+          type: "u32", // The legacy native program only accepts 4-byte instruction discriminants.
+        },
+      })),
+    }),
     idlName: 'idl',
     programDir,
     binaryInstallDir,


### PR DESCRIPTION
> [!WARNING]
> I'm pretty sure that this is not landable, because if the legacy built-in and this program have different discriminator sizes, then the _actual_ instruction data will not line up when we switch from one to the other. I couldn't find a way to configure Shank macros to produce 4-byte discriminants.

Fixes: #4.